### PR TITLE
Fix Properties for Time Lapse Data + Move Property Setting / Parsing to a Background Thread

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,6 @@
     <script src="third_party/auto-complete.min.js"></script>
     <script src="third_party/jszip.min.js"></script>
     <script src="third_party/jmuxer.min.js"></script>
-    <script src="third_party/protobuf.min.js"></script>
 
     <script src="js/constants.js"></script>
     <script src="js/utils.js"></script>

--- a/js/activity_list.js
+++ b/js/activity_list.js
@@ -33,7 +33,6 @@ const activityListAction = function (initializer) {
         };
 
         if (info.type == TYPE_TIME_LAPSE_BUG_REPORT) {
-            toast("Loading time lapse data. This can take longer than 10 seconds.")
             tlHvAction(info)
         } else {
             hViewAction(info);

--- a/js/ddmlib/property_formatter.js
+++ b/js/ddmlib/property_formatter.js
@@ -1,0 +1,107 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const EXCLUSION_LIST = [ "toJSON", "$type", "constructor", "namedProperties", "properties", "children", "classname", "name", "boxPos", "boxStylePos", "desc" ]
+
+const LAYOUT_TYPE = "Layout"
+const DRAWING_TYPE = "Drawing"
+const SCROLLING_TYPE = "Scrolling"
+const MISC_TYPE = "Misc"
+const DEFAULT_TYPE = "Unspecified"
+
+const PROPERTY_TYPE_MAP = new Map()
+PROPERTY_TYPE_MAP.set("left", LAYOUT_TYPE)
+PROPERTY_TYPE_MAP.set("top", LAYOUT_TYPE)
+PROPERTY_TYPE_MAP.set("width", LAYOUT_TYPE)
+PROPERTY_TYPE_MAP.set("height", LAYOUT_TYPE)
+PROPERTY_TYPE_MAP.set("scrollX", SCROLLING_TYPE)
+PROPERTY_TYPE_MAP.set("scrollY", SCROLLING_TYPE)
+PROPERTY_TYPE_MAP.set("translationX", DRAWING_TYPE)
+PROPERTY_TYPE_MAP.set("translationY", DRAWING_TYPE)
+PROPERTY_TYPE_MAP.set("scaleX", DRAWING_TYPE)
+PROPERTY_TYPE_MAP.set("scaleY", DRAWING_TYPE)
+PROPERTY_TYPE_MAP.set("alpha", DRAWING_TYPE)
+PROPERTY_TYPE_MAP.set("willNotDraw", DRAWING_TYPE)
+PROPERTY_TYPE_MAP.set("clipChildren", DRAWING_TYPE)
+PROPERTY_TYPE_MAP.set("visibility", MISC_TYPE)
+PROPERTY_TYPE_MAP.set("id", DEFAULT_TYPE)
+
+/* returns the root ViewNode that was passed in and altered */
+const formatProperties = function(root /* ViewNode */) {
+    function inner(node /* ViewNode */,
+                   maxW /* Int */,
+                   maxH /* Int */,
+                   leftShift /* Int */,
+                   topShift /* Int */,
+                   scaleX /* Int */,
+                   scaleY /* Int */) {
+        const newScaleX = scaleX * node.scaleX
+        const newScaleY = scaleY * node.scaleY
+
+        const l = leftShift + (node.left + node.translationX) * scaleX + node.width * (scaleX - newScaleX) / 2
+        const t = topShift + (node.top + node.translationY) * scaleY + node.height * (scaleY - newScaleY) / 2
+        node.boxPos = {
+            left: l,
+            top: t,
+            width: node.width * newScaleX,
+            height: node.height * newScaleY,
+        }
+
+        node.boxStylePos = {
+            left: (node.boxPos.left * 100 / maxW) + "%",
+            top: (node.boxPos.top * 100 / maxH) + "%",
+            width: (node.boxPos.width * 100 / maxW) + "%",
+            height: (node.boxPos.height * 100 / maxH) + "%"
+        }
+
+        if (node.name == undefined) {
+            node.name = node.classname
+        }
+
+        let tName = node.name.split(".");
+        node.name = tName[tName.length - 1];
+
+        if (node.contentDesc != null) {
+            node.name = node.name + " : " + node.contentDesc;
+        }
+        node.desc = node.name;
+
+        for (let i = 0; i < node.children.length; i++) {
+            node.children[i].parent = node;
+            inner(node.children[i], maxW, maxH, l - node.scrollX, t - node.scrollY, newScaleX, newScaleY);
+        }
+
+        if (node.properties == undefined) {
+            node.properties = []
+
+            for (const propertyName in node) {
+                if (!EXCLUSION_LIST.includes(propertyName)) {
+                    const property = new VN_Property(propertyName)
+                    property.value = node[propertyName]
+                    property.type = PROPERTY_TYPE_MAP.get(propertyName) || DEFAULT_TYPE
+                    node.properties.push(property)
+                }
+            }
+        }
+        node.namedProperties = {};
+        for (let i = 0; i < node.properties.length; i++) {
+            node.namedProperties[node.properties[i].fullname] = node.properties[i];
+        }
+    }
+
+    root.scaleX = root.scaleY = 1;
+    root.translationX = root.translationY = 1;
+    inner(root, root.width, root.height, 0, 0, 1, 1)
+    return root
+}

--- a/js/ddmlib/tl-worker.js
+++ b/js/ddmlib/tl-worker.js
@@ -1,0 +1,33 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+importScripts("property_formatter.js");
+importScripts("../../third_party/protobuf.min.js")
+importScripts("../utils.js")
+importScripts("../constants.js")
+importScripts("viewnode.js")
+
+self.onmessage = function(event) {
+    const base64String = event.data.bugReportLine.replace(VIEW_CAPTURE_REGEX, "")
+
+    protobuf.load("../../protos/view_capture.proto").then(function(root) {
+        postMessage({
+            rootNodes: root.lookupType("com.android.launcher3.view.ExportedData")
+                           .decode(base64ToUint8Array(base64String))
+                           .frameData
+                           .map(f => formatProperties(f.node))
+        });
+        close();
+    })
+}

--- a/js/ddmlib/worker.js
+++ b/js/ddmlib/worker.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 importScripts("viewnode.js");
+importScripts("property_formatter.js");
 
 const CMD_CONVERT_TO_STRING = 1;
 const CMD_PARSE_OLD_DATA = 2;
@@ -80,6 +81,8 @@ self.onmessage = function(e) {
     }
 
     const rootNode = parseNode(data, bitShift);
+    formatProperties(rootNode);
+
     postMessage({
         root: rootNode
     });

--- a/js/hview.js
+++ b/js/hview.js
@@ -414,12 +414,10 @@ $(function () {
             }
         }
 
-        if (this.node.properties != undefined) {
-            for (let i = 0; i < this.node.properties.length; i++) {
-                const p = this.node.properties[i];
-                if (favoriteProperties.indexOf(p.fullname) < 0) {
-                    addProp(p, p.type);
-                }
+        for (let i = 0; i < this.node.properties.length; i++) {
+            const p = this.node.properties[i];
+            if (favoriteProperties.indexOf(p.fullname) < 0) {
+                addProp(p, p.type);
             }
         }
         filterProperties();
@@ -517,40 +515,17 @@ $(function () {
         $(this).parent().dblclick();
     }
 
-    const renderNode = function (node, container, boxContainer, maxW, maxH, leftShift, topShift, scaleX, scaleY) {
-        const newScaleX = scaleX * node.scaleX;
-        const newScaleY = scaleY * node.scaleY;
-
-        const l = leftShift + (node.left + node.translationX) * scaleX + node.width * (scaleX - newScaleX) / 2;
-        const t = topShift + (node.top + node.translationY) * scaleY + node.height * (scaleY - newScaleY) / 2;
-        const boxPos = {
-            left: l,
-            top: t,
-            width: node.width * newScaleX,
-            height: node.height * newScaleY,
-        };
-
+    const renderNode = function (node, container, boxContainer) {
         const box = divProtoType.cloneNode()
-        box.style.left = (boxPos.left * 100 / maxW) + "%"
-        box.style.top = (boxPos.top * 100 / maxH) + "%"
-        box.style.width = (boxPos.width * 100 / maxW) + "%"
-        box.style.height = (boxPos.height * 100 / maxH) + "%"
-        boxContainer.appendChild(box)
+        box.style.left = node.boxStylePos.left;
+        box.style.top = node.boxStylePos.top;
+        box.style.width = node.boxStylePos.width;
+        box.style.height = node.boxStylePos.height;
         box.node = node
-
-        if (node.name == undefined)
-            node.name = node.classname
-        let name = node.name.split(".");
-        name = name[name.length - 1];
-
-        const desc = node.contentDesc;
-        if (desc != null) {
-            name = name + " : " + desc;
-        }
-        node.desc = name;
+        boxContainer.appendChild(box)
 
         const elWrap = xlinewrapProtoType.cloneNode()
-        elWrap.appendChild(document.createTextNode(name))
+        elWrap.appendChild(document.createTextNode(node.name))
         elWrap.appendChild(xprofileProtoType.cloneNode())
     
         const el = labelProtoType.cloneNode()
@@ -562,11 +537,11 @@ $(function () {
         el.appendChild(elWrap)
         el.node = node
         el.box = box
+
         box.el = el
 
         node.box = box
         node.el = el
-        node.boxpos = boxPos;
 
         const span = spanProtoType.cloneNode()
         elWrap.insertBefore(span, null)
@@ -577,10 +552,8 @@ $(function () {
             el.ondblclick = treeToggle
             const newContainer = newContainerProtoType.cloneNode()
             container.appendChild(newContainer)
-            const shiftX = l - node.scrollX;
-            const shiftY = t - node.scrollY;
             for (let i = 0; i < node.children.length; i++) {
-                renderNode(node.children[i], newContainer, boxContainer, maxW, maxH, shiftX, shiftY, newScaleX, newScaleY);
+                renderNode(node.children[i], newContainer, boxContainer);
             }
         }
     }
@@ -590,11 +563,7 @@ $(function () {
         vListContent.replaceChildren();
         boxContent.replaceChildren();
 
-        // Clear all transform from the root, so that it matches the preview
-        root.scaleX = root.scaleY = 1;
-        root.translationX = root.translationY = 1;
-
-        renderNode(root, vListContent, boxContent, root.width, root.height, 0, 0, 1, 1)
+        renderNode(root, vListContent, boxContent)
     }
 
     /********************************* Refresh view *********************************/

--- a/js/index.js
+++ b/js/index.js
@@ -196,3 +196,11 @@ function switchTheme() {
 function isDarkTheme() {
 	return localStorage.isDarkTheme == "true";
 }
+
+/**
+ * Adds a node displaying the error message in the container
+ */
+$.fn.showError = function(msg) {
+  $("#main-progress").hide();
+  return this.empty().removeClass("hide").removeClass("hidden").append($("<span>").text(msg).addClass("error"));
+}

--- a/js/utils.js
+++ b/js/utils.js
@@ -82,14 +82,6 @@ async function saveFile(fileName, url) {
     }, 0);
 }
 
-/**
- * Adds a node displaying the error message in the continer
- */
-$.fn.showError = function(msg) {
-  $("#main-progress").hide();
-  return this.empty().removeClass("hide").removeClass("hidden").append($("<span>").text(msg).addClass("error"));
-}
-
 function showContext(menu, callback, e) {
     const elementFactory = function(el, hideMenu) {
         const menuClickHandler = function() {


### PR DESCRIPTION
1. The ViewHierarchy Node Properties View was fixed by formatting the ViewNode's internal structure.
2. Because this code was similar for all ViewHierarchy data, it was moved into a shared method that both TimeLapse and non-Timelapse data use.
3. All node property formatting was moved off the main thread.
4. All TimeLapse data node parsing was moved off the main thread.