### PR TITLE
Fix bug where image preview wasn't loading even though screenshot existed.

### DIFF
--- a/js/ddmlib/parser_v1.js
+++ b/js/ddmlib/parser_v1.js
@@ -87,6 +87,5 @@ const parseNode = function(data) {
         }
     }
 
-    root.updateNodeDrawn();
     return root;
 }

--- a/js/ddmlib/parser_v2.js
+++ b/js/ddmlib/parser_v2.js
@@ -140,7 +140,6 @@ const parseNode = function(bytes, bitShift) {
     }
 
     const root = parseNodeObj(views[0]);
-    root.updateNodeDrawn();
 
     const windowLeftIndex = pTable.indexOf("window:left");
     const windowTopIndex = pTable.indexOf("window:top");

--- a/js/ddmlib/property_formatter.js
+++ b/js/ddmlib/property_formatter.js
@@ -21,6 +21,7 @@ const EXCLUSION_LIST = new Set([
     "children",
     "parent",
     "classname",
+    "simpleName",
     "name",
     "boxPos",
     "boxStylePos",
@@ -84,8 +85,8 @@ const formatProperties = function(root /* ViewNode */) {
             node.name = node.classname
         }
 
-        let tName = node.name.split(".");
-        node.name = tName[tName.length - 1];
+        node.simpleName = node.name.split(".")
+        node.simpleName = node.simpleName[node.simpleName.length - 1];
 
         if (node.contentDesc != null) {
             node.name = node.name + " : " + node.contentDesc;

--- a/js/ddmlib/property_formatter.js
+++ b/js/ddmlib/property_formatter.js
@@ -12,7 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const EXCLUSION_LIST = new Set([ "toJSON", "$type", "constructor", "namedProperties", "properties", "children", "parent", "classname", "name", "boxPos", "boxStylePos", "desc" ])
+const EXCLUSION_LIST = new Set([
+    "toJSON",
+    "$type",
+    "constructor",
+    "namedProperties",
+    "properties",
+    "children",
+    "parent",
+    "classname",
+    "name",
+    "boxPos",
+    "boxStylePos",
+    "desc",
+    "isVisible",
+    "nodeDrawn"
+])
 
 const LAYOUT_TYPE = "Layout"
 const DRAWING_TYPE = "Drawing"
@@ -76,10 +91,13 @@ const formatProperties = function(root /* ViewNode */) {
             node.name = node.name + " : " + node.contentDesc;
         }
         node.desc = node.name;
+        node.isVisible = node.visibility == 0 || node.visibility == "VISIBLE" || !node.visibility
+        node.nodeDrawn = !node.willNotDraw;
 
         for (let i = 0; i < node.children.length; i++) {
-            node.children[i].parent = node;
             inner(node.children[i], maxW, maxH, l - node.scrollX, t - node.scrollY, newScaleX, newScaleY);
+            node.children[i].parent = node;
+            node.nodeDrawn |= (node.children[i].nodeDrawn && node.children[i].isVisible);
         }
 
         if (node.properties == undefined) {

--- a/js/ddmlib/viewnode.js
+++ b/js/ddmlib/viewnode.js
@@ -71,14 +71,6 @@ ViewNode.prototype.getFloat  = function(name, dValue) {
     return dValue;
 }
 
-ViewNode.prototype.updateNodeDrawn = function() {
-    this.nodeDrawn = !this.willNotDraw;
-    for (let i = 0; i < this.children.length; i++) {
-        this.children[i].updateNodeDrawn();
-        this.nodeDrawn |= (this.children[i].nodeDrawn && this.children[i].isVisible);
-    }
-}
-
 ViewNode.prototype.sortProperties = function() {
     this.properties.sort(function (a, b) {
         if (a.type > b.type) {

--- a/js/hview.js
+++ b/js/hview.js
@@ -245,11 +245,11 @@ $(function () {
             if (node == currentRootNode) {
                 $("#border-box").css('background-image', 'url("' + node.imageUrl + '")');
             }
-            if (node.box.hasClass(CLS_SELECTED)) {
-                node.box.css('background-image', 'url("' + node.imageUrl + '")');
+            if (node.box.classList.contains(CLS_SELECTED)) {
+                node.box.style.backgroundImage = 'url("' + node.imageUrl + '")'
                 $("#image-preview").empty().css('background-image', 'url("' + node.imageUrl + '")');
             }
-        }).catch(() => {
+        }).catch((e) => {
             node.imageUrl = null;
             if (node.box.classList.contains(CLS_SELECTED)) {
                 $("#image-preview").showError("Error loading image");
@@ -319,7 +319,7 @@ $(function () {
         if (this.node.imageUrl == URL_LOADING) {
             // Show a loading message
         } else if (this.node.imageUrl) {
-            box.css('background-image', 'url("' + this.node.imageUrl + '")');
+            this.box.style.backgroundImage = 'url("' + this.node.imageUrl + '")'
             $("#image-preview").empty().css('background-image', 'url("' + this.node.imageUrl + '")');
         } else {
             loadImage(this.node);
@@ -569,7 +569,7 @@ $(function () {
         boxContainer.appendChild(box)
 
         const elWrap = xlinewrapProtoType.cloneNode()
-        elWrap.appendChild(document.createTextNode(node.name))
+        elWrap.appendChild(document.createTextNode(node.simpleName))
         elWrap.appendChild(xprofileProtoType.cloneNode())
     
         const el = labelProtoType.cloneNode()

--- a/js/hview.js
+++ b/js/hview.js
@@ -873,7 +873,7 @@ $(function () {
             }
             parent = parent.parent;
         }
-        scrollToView(node.el, $("#vlist_content"));
+        scrollToView($(node.el), $("#vlist_content"));
     }
 
     /* TODO: When selecting UX element, select the top-most element. Currently, clicking on anything 
@@ -886,24 +886,17 @@ $(function () {
         const heightFactor = currentRootNode.height / $(this).height();
 
         const updateSelection = function (node, x, y, firstNoDrawChild, clipX1, clipY1, clipX2, clipY2) {
-            if (node.disablePreview) {
-                return null;
-            }
-            if (!node.nodeDrawn) {
-                return null;
-            }
-            if (nodesHidden && !node.isVisible) {
+            if (node.disablePreview || !node.nodeDrawn || (nodesHidden && !node.isVisible)) {
                 return null;
             }
 
             const wasFirstNoDrawChildNull = firstNoDrawChild[0] == null;
-            const boxpos = node.boxpos;
 
-            const boxRight = boxpos.width + boxpos.left;
-            const boxBottom = boxpos.top + boxpos.height;
+            const boxRight = node.boxPos.width + node.boxPos.left;
+            const boxBottom = node.boxPos.top + node.boxPos.height;
             if (node.clipChildren) {
-                clipX1 = Math.max(clipX1, boxpos.left);
-                clipY1 = Math.max(clipY1, boxpos.top);
+                clipX1 = Math.max(clipX1, node.boxPos.left);
+                clipY1 = Math.max(clipY1, node.boxPos.top);
                 clipX2 = Math.min(clipX2, boxRight);
                 clipY2 = Math.min(clipY2, boxBottom);
             }
@@ -916,7 +909,7 @@ $(function () {
                     }
                 }
             }
-            if (boxpos.left < x && boxRight > x && boxpos.top < y && boxBottom > y) {
+            if (node.boxPos.left < x && boxRight > x && node.boxPos.top < y && boxBottom > y) {
                 if (node.willNotDraw) {
                     if (firstNoDrawChild[0] == null) {
                         firstNoDrawChild[0] = node;
@@ -1404,7 +1397,7 @@ $(function () {
     /** ********************** Show/hide hidden nodes ********************** */
     // Hides the node and all its children recursively.
     const hideNode = function (node, hide) {
-        hide = hide || !(node.isVisible || node.visibility == VIEW_VISIBLE);
+        hide = hide || !node.isVisible
         if (hide) {
             node.box.style.display = "none"
             node.el.style.display = "none"


### PR DESCRIPTION
The image loading code uses the node name to get the correct image. The node tree code displays a simpler name to the user. The fix was simply to split these values out into 2 separate properties.