### PR TITLE
Show a sub icon that indicates whether a bug report activity has time  lapse data or just a single view hierarchy.

### DIFF
--- a/css/dlist.css
+++ b/css/dlist.css
@@ -79,9 +79,22 @@
     width: 36px;
     height: 36px;
     float: left;
+    position: relative;
     margin-right: 8px;
     background: url(app_icon.png) no-repeat center center;
     background-size: 100%;
+}
+
+.activity-list .subIcon {
+    color: black;
+    height: 18px;
+    width: 18px;
+    font-size: 18px;
+    border-radius: 3px;
+    background-color: white;
+    position: absolute;
+    bottom: -5px;
+    right: -5px;
 }
 
 .old-api {

--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
     <link href="css/app.css" rel="stylesheet" />
     <link href="css/dlist.css" rel="stylesheet" />
     <link href="css/hview.css" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
     <script src="third_party/crypto.min.js"></script>

--- a/js/activity_list.js
+++ b/js/activity_list.js
@@ -66,6 +66,11 @@ const activityListAction = function (initializer) {
                 if (l.icon && l.icon.value) {
                     icon.css("background-image", `url(${l.icon.value})`);
                 }
+                if (l.subIcon) {
+                    $("<i>").addClass("material-icons subIcon")
+                            .appendTo(icon)
+                            .text(l.subIcon)
+                }
             }
 
             if (l.name == "") {

--- a/js/constants.js
+++ b/js/constants.js
@@ -41,5 +41,7 @@ const CMD_USE_PROPERTY_MAP = 4;
 const CMD_DEFLATE_STRING = 8;
 const CMD_SKIP_8_BITS = 16;
 
+const TIME_LAPSE_SUB_ICON = "filter_2"
+const SINGLE_VIEW_HIERARCHY_SUB_ICON = "looks_one"
 const VIEW_VISIBLE = 0;
 const VIEW_CAPTURE_REGEX = /^\s*mViewCapture:\s*/

--- a/js/ddmlib/parser_v1.js
+++ b/js/ddmlib/parser_v1.js
@@ -87,6 +87,5 @@ const parseNode = function(data) {
         }
     }
 
-    root.updateNodeDrawn();
     return root;
 }

--- a/js/ddmlib/parser_v2.js
+++ b/js/ddmlib/parser_v2.js
@@ -140,7 +140,6 @@ const parseNode = function(bytes, bitShift) {
     }
 
     const root = parseNodeObj(views[0]);
-    root.updateNodeDrawn();
 
     const windowLeftIndex = pTable.indexOf("window:left");
     const windowTopIndex = pTable.indexOf("window:top");

--- a/js/ddmlib/property_formatter.js
+++ b/js/ddmlib/property_formatter.js
@@ -12,7 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const EXCLUSION_LIST = new Set([ "toJSON", "$type", "constructor", "namedProperties", "properties", "children", "parent", "classname", "name", "boxPos", "boxStylePos", "desc" ])
+const EXCLUSION_LIST = new Set([
+    "toJSON",
+    "$type",
+    "constructor",
+    "namedProperties",
+    "properties",
+    "children",
+    "parent",
+    "classname",
+    "name",
+    "boxPos",
+    "boxStylePos",
+    "desc",
+    "isVisible",
+    "nodeDrawn"
+])
 
 const LAYOUT_TYPE = "Layout"
 const DRAWING_TYPE = "Drawing"
@@ -76,10 +91,13 @@ const formatProperties = function(root /* ViewNode */) {
             node.name = node.name + " : " + node.contentDesc;
         }
         node.desc = node.name;
+        node.isVisible = node.visibility == 0 || node.visibility == "VISIBLE" || !node.visibility
+        node.nodeDrawn = !node.willNotDraw;
 
         for (let i = 0; i < node.children.length; i++) {
-            node.children[i].parent = node;
             inner(node.children[i], maxW, maxH, l - node.scrollX, t - node.scrollY, newScaleX, newScaleY);
+            node.children[i].parent = node;
+            node.nodeDrawn |= (node.children[i].nodeDrawn && node.children[i].isVisible);
         }
 
         if (node.properties == undefined) {

--- a/js/ddmlib/viewnode.js
+++ b/js/ddmlib/viewnode.js
@@ -71,14 +71,6 @@ ViewNode.prototype.getFloat  = function(name, dValue) {
     return dValue;
 }
 
-ViewNode.prototype.updateNodeDrawn = function() {
-    this.nodeDrawn = !this.willNotDraw;
-    for (let i = 0; i < this.children.length; i++) {
-        this.children[i].updateNodeDrawn();
-        this.nodeDrawn |= (this.children[i].nodeDrawn && this.children[i].isVisible);
-    }
-}
-
 ViewNode.prototype.sortProperties = function() {
     this.properties.sort(function (a, b) {
         if (a.type > b.type) {

--- a/js/file_load_worker.js
+++ b/js/file_load_worker.js
@@ -44,6 +44,7 @@ async function handleLoadFile(reader) {
                         name: x,
                         data: viewDumpZip.files[x].asUint8Array(),
                         type: TYPE_BUG_REPORT_V2,
+                        subIcon: SINGLE_VIEW_HIERARCHY_SUB_ICON,
                         display: display_size
                     })
                 }
@@ -143,6 +144,7 @@ async function loadBugFile(bugFile, list) {
                 name: "Launcher's View Capture",
                 data: tlHvDataAsBinaryArray,
                 type: TYPE_TIME_LAPSE_BUG_REPORT,
+                subIcon: TIME_LAPSE_SUB_ICON,
                 display: { }
             })
         } else {
@@ -197,6 +199,7 @@ async function loadBugFile(bugFile, list) {
     }
 
     list.use_new_api = false;
+    list.hasIcons = true
     postMessage({type: TYPE_BUG_REPORT, list: list});
 }
 

--- a/js/hview.js
+++ b/js/hview.js
@@ -873,7 +873,7 @@ $(function () {
             }
             parent = parent.parent;
         }
-        scrollToView(node.el, $("#vlist_content"));
+        scrollToView($(node.el), $("#vlist_content"));
     }
 
     /* TODO: When selecting UX element, select the top-most element. Currently, clicking on anything 
@@ -886,24 +886,17 @@ $(function () {
         const heightFactor = currentRootNode.height / $(this).height();
 
         const updateSelection = function (node, x, y, firstNoDrawChild, clipX1, clipY1, clipX2, clipY2) {
-            if (node.disablePreview) {
-                return null;
-            }
-            if (!node.nodeDrawn) {
-                return null;
-            }
-            if (nodesHidden && !node.isVisible) {
+            if (node.disablePreview || !node.nodeDrawn || (nodesHidden && !node.isVisible)) {
                 return null;
             }
 
             const wasFirstNoDrawChildNull = firstNoDrawChild[0] == null;
-            const boxpos = node.boxpos;
 
-            const boxRight = boxpos.width + boxpos.left;
-            const boxBottom = boxpos.top + boxpos.height;
+            const boxRight = node.boxPos.width + node.boxPos.left;
+            const boxBottom = node.boxPos.top + node.boxPos.height;
             if (node.clipChildren) {
-                clipX1 = Math.max(clipX1, boxpos.left);
-                clipY1 = Math.max(clipY1, boxpos.top);
+                clipX1 = Math.max(clipX1, node.boxPos.left);
+                clipY1 = Math.max(clipY1, node.boxPos.top);
                 clipX2 = Math.min(clipX2, boxRight);
                 clipY2 = Math.min(clipY2, boxBottom);
             }
@@ -916,7 +909,7 @@ $(function () {
                     }
                 }
             }
-            if (boxpos.left < x && boxRight > x && boxpos.top < y && boxBottom > y) {
+            if (node.boxPos.left < x && boxRight > x && node.boxPos.top < y && boxBottom > y) {
                 if (node.willNotDraw) {
                     if (firstNoDrawChild[0] == null) {
                         firstNoDrawChild[0] = node;
@@ -1404,7 +1397,7 @@ $(function () {
     /** ********************** Show/hide hidden nodes ********************** */
     // Hides the node and all its children recursively.
     const hideNode = function (node, hide) {
-        hide = hide || !(node.isVisible || node.visibility == VIEW_VISIBLE);
+        hide = hide || !node.isVisible
         if (hide) {
             node.box.style.display = "none"
             node.el.style.display = "none"


### PR DESCRIPTION
New activity list UX for bug reports:
![image](https://user-images.githubusercontent.com/104465970/182714091-6f360b8b-abe9-4aba-a4d4-eed51db6ff6b.png)

Regression testing for live devices activity lists:
![image](https://user-images.githubusercontent.com/104465970/182714102-d0d8a605-dbe3-423b-9a46-1a480a15889b.png)
